### PR TITLE
[requif/issues #3] Fix specs

### DIFF
--- a/lib/reqif/high_precision_date_time.rb
+++ b/lib/reqif/high_precision_date_time.rb
@@ -2,15 +2,18 @@ require "lutaml/model/type/date_time"
 
 module Reqif
   class HighPrecisionDateTime < Lutaml::Model::Type::DateTime
+    def self.serialize(value)
+      return nil if value.nil?
 
-    # The format looks like this `2012-04-07T01:51:37.112+02:00`
-    def self.from_xml(xml_string)
-      ::DateTime.parse(xml_string)
+      cast(value)&.iso8601(8)
     end
 
-    # The %L adds milliseconds to the time
+    def to_json
+      value.to_time.iso8601(8)
+    end
+
     def to_xml
-      value.strftime("%Y-%m-%dT%H:%M:%S.%L99999%:z")
+      value.to_time.iso8601(8)
     end
   end
 end


### PR DESCRIPTION
## MOTIVATION
I don't want to see the bad spec.

## Reason
I want the date and time to match with milliseconds when parsing. 

## Description
Issue https://github.com/lutaml/reqif/issues/3

## Result

for tests you can use the code:
```ruby
require 'lutaml/model'

Lutaml::Model::Config.configure do |config|
  require 'lutaml/model/xml_adapter/nokogiri_adapter'
  config.xml_adapter = Lutaml::Model::XmlAdapter::NokogiriAdapter
end

class Kiln < Lutaml::Model::Serializable
  attribute :time1, :date_time
  attribute :time2, :time
  attribute :time3, Reqif::HighPrecisionDateTime
end

a = Kiln.new(time1: Time.now, time2: Time.now, time3: Time.now)
b = Kiln.from_json(a.to_json)
c = Kiln.from_xml(a.to_xml)

puts "FOR JSON"
puts "date_time #{a.time1 == b.time1}"
puts "time #{a.time2 == b.time2}"
puts "HighPrecisionDateTime #{a.time3 == b.time3}"
 
puts "FOR XML"
puts "date_time #{a.time1 == c.time1}"
puts "time #{a.time2 == c.time2}"
puts "HighPrecisionDateTime #{a.time3 == c.time3}"
```

**Output**
```bash
FOR JSON
date_time false
time false
HighPrecisionDateTime true

FOR XML
date_time false
time false
HighPrecisionDateTime true
```


### Before
```ruby
2014-07-09T10:19:00.12345678-04:00
2014-07-09T10:19:00-04:00
```

### After
```ruby
2014-07-09T10:19:00.12345678-04:00
2014-07-09T10:19:00.12345678-04:00
```

## Changes
- [x] Fixed Reqif::HighPrecisionDateTime
